### PR TITLE
Improved Stability, two bug fixes

### DIFF
--- a/cloudwatch/cloudwatch.rb
+++ b/cloudwatch/cloudwatch.rb
@@ -7,7 +7,7 @@ require 'getoptlong'
 require 'copperegg'
 require 'json'
 require 'yaml'
-require 'aws'
+require 'aws-sdk'
 
 ####################################################################
 
@@ -406,7 +406,7 @@ puts "Checking for existence of metric group for AWS"
 ce_metrics = CopperEgg::Metrics.new(apikey, @apihost)
 mgroup = ce_metrics.metric_group("aws_ec2")
 
-if !mgroup.nil?
+if mgroup.nil?
   # no metric group found - create one
   create_aws_metric_groups(apikey)
 end


### PR DESCRIPTION
1. Wrapped fetch_cloudwatch_stats request with begin-recue-end to prevent  exceptions from killing the  cloudwatch process,
2. changed require 'aws' to require 'aws-sdk' (bugfix)
3. fixed the metric group check logic. (bugfix)
