### PR TITLE
Update README.md

### DIFF
--- a/cloudwatch/README.md
+++ b/cloudwatch/README.md
@@ -74,8 +74,8 @@ Ensure that current ruby gems are installed.
 From the metrics-plugins directory:
 
     gem install nokogiri --no-ri --no-rdoc
-    gem install aws-sdk --no-ri --no-rdoc
-    gem install copperegg -v 0.6.0 --no-ri --no-rdoc
+    gem install aws-sdk-v1 --no-ri --no-rdoc
+    gem install copperegg --no-ri --no-rdoc
 
 ##4. Run the agent
 


### PR DESCRIPTION
This was originally written for version 1 of the aws-sdk gem. 
Now that there are newer aws-sdk versions... this needs to use the older v1 gem.