### PR TITLE
Installation scripts do not respect gem version specified in Gemfile

### DIFF
--- a/couchdb/couchdb.rb
+++ b/couchdb/couchdb.rb
@@ -4,6 +4,7 @@
 #
 
 require 'rubygems'
+require 'bundler/setup'
 require 'getoptlong'
 require 'copperegg'
 require 'json/pure'

--- a/couchdb/couchdb.rb
+++ b/couchdb/couchdb.rb
@@ -3,6 +3,11 @@
 # Copyright 2013 IDERA.  All rights reserved.
 #
 
+base_path = '/usr/local/copperegg/ucm-metrics/couchdb'
+ENV['BUNDLE_GEMFILE'] = "#{base_path}/Gemfile"
+
+##################################################
+
 require 'rubygems'
 require 'bundler/setup'
 require 'getoptlong'
@@ -82,7 +87,6 @@ opts = GetoptLong.new(
   ['--apihost',   '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-base_path = '/usr/local/copperegg/ucm-metrics/couchdb'
 config_file = "#{base_path}/config.yml"
 @apihost = nil
 @debug = false

--- a/couchdb/couchdb_installer.sh
+++ b/couchdb/couchdb_installer.sh
@@ -441,8 +441,20 @@ echo "Monitoring frequency set to one sample per $FREQ seconds."
 echo
 
 echo "Installing required gems "
-echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
-    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+echo "Installing gem bundler"
+gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+install_rc=$?
+if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem bundler did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install bundler -v 1.12.5 ' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+fi
 
 OLDIFS=$IFS
 IFS=$'\n'

--- a/couchdb/couchdb_installer.sh
+++ b/couchdb/couchdb_installer.sh
@@ -344,7 +344,7 @@ create_exe_file()
     if [ -n "$RVM_SCRIPT" ]; then
         cat <<ENDINIT > $LAUNCHER_FILE
 #!/bin/bash
-DIRNAME="`dirname \$0`"
+DIRNAME="/usr/local/copperegg/ucm-metrics/couchdb"
 . $RVM_SCRIPT
 cd \$DIRNAME
 $AGENT_FILE \$*
@@ -439,30 +439,36 @@ fi
 echo "Monitoring frequency set to one sample per $FREQ seconds."
 
 echo
-for THIS_GEM in `cat couchdb/Gemfile |grep '^[ ]*gem' |awk '{print $2}' | sed -r -e "s/[',]//g"`; do
-    echo "Installing gem $THIS_GEM..."
-    if [ -n "$PRE" -a -n "`echo $THIS_GEM | egrep copperegg`" ]; then
-        # install prerelease gems if "$PRE" is not null, but only for copperegg
-        gem install --no-ri --no-rdoc $THIS_GEM --pre --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
-    else
-        gem install --no-ri --no-rdoc $THIS_GEM --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
-    fi
-    install_rc=$?
-    if [ $install_rc -ne 0 ]; then
-        echo
-        echo "********************************************************"
-        echo "********************************************************"
-        echo "*** "
-        echo "*** WARNING: gem $THIS_GEM did not install properly!"
-        echo "*** Please contact support-uptimecm@idera.com if you are"
-        echo "*** unable to run 'gem install $THIS_GEM' manually."
-        echo "*** "
-        echo "********************************************************"
-        echo "********************************************************"
-        echo
-    fi
-done
 
+echo "Installing required gems "
+echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
+    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+
+OLDIFS=$IFS
+IFS=$'\n'
+gems=`grep -w gem couchdb/Gemfile | awk '{$1="" ; print $0}'`
+
+for gem in $gems; do
+  gem_name=`echo $gem | awk -F "," '{print $1}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+  gem_version=`echo $gem | awk -F "," '{print $2}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+
+  echo "Installing gem $gem_name [Using gem install $gem_name -v \"$gem_version\"]"
+
+  gem install $gem_name -v "$gem_version" >> $PKG_INST_OUT
+  install_rc=$?
+  if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem $gem did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install $gem_name -v \"$gem_version\"' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+  fi
+done
+IFS=$OLDIFS
 
 #
 # create config.yml

--- a/couchdb/couchdb_installer.sh
+++ b/couchdb/couchdb_installer.sh
@@ -449,20 +449,29 @@ IFS=$'\n'
 gems=`grep -w gem couchdb/Gemfile | awk '{$1="" ; print $0}'`
 
 for gem in $gems; do
-  gem_name=`echo $gem | awk -F "," '{print $1}' | tr -d \' | tr -d \" | tr -d [:blank:]`
-  gem_version=`echo $gem | awk -F "," '{print $2}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+  gem=${gem//[\'\" ]/}
+  IFS=',' read -r -a array <<< "$gem"
+  echo "Installing gem ${array[0]}"
+  if [ -z "${array[1]}" ]
+    then
+    gem install --no-ri --no-rdoc ${array[0]} >> $PKG_INST_OUT
+  else
+    gem install --no-ri --no-rdoc ${array[0]} -v ${array[1]} >> $PKG_INST_OUT
+  fi
 
-  echo "Installing gem $gem_name [Using gem install $gem_name -v \"$gem_version\"]"
-
-  gem install $gem_name -v "$gem_version" >> $PKG_INST_OUT
   install_rc=$?
   if [ $install_rc -ne 0 ]; then
     echo
     echo "********************************************************"
     echo "*** "
-    echo "*** WARNING: gem $gem did not install properly!"
+    echo "*** WARNING: gem ${array[0]} did not install properly!"
     echo "*** Please contact support-uptimecm@idera.com if you are"
-    echo "*** unable to run 'gem install $gem_name -v \"$gem_version\"' manually."
+    if [ -z "${array[1]}" ]
+      then
+      echo "*** unable to run 'gem install ${array[0]}' manually."
+    else
+      echo "*** unable to run 'gem install ${array[0]} -v \"${array[1]}\"' manually."
+    fi
     echo "*** "
     echo "********************************************************"
     echo

--- a/dns/dns.rb
+++ b/dns/dns.rb
@@ -4,6 +4,7 @@
 #
 
 require 'rubygems'
+require 'bundler/setup'
 require 'getoptlong'
 require 'copperegg'
 require 'json/pure'

--- a/dns/dns.rb
+++ b/dns/dns.rb
@@ -3,6 +3,11 @@
 # Copyright 2016 IDERA.  All rights reserved.
 #
 
+base_path = '/usr/local/copperegg/ucm-metrics/dns'
+ENV['BUNDLE_GEMFILE'] = "#{base_path}/Gemfile"
+
+##################################################
+
 require 'rubygems'
 require 'bundler/setup'
 require 'getoptlong'
@@ -84,7 +89,7 @@ opts = GetoptLong.new(
   ['--apihost',   '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-base_path = '/usr/local/copperegg/ucm-metrics/dns'
+
 config_file = "#{base_path}/config.yml"
 @apihost = nil
 @debug = false

--- a/dns/dns_installer.sh
+++ b/dns/dns_installer.sh
@@ -384,7 +384,7 @@ create_exe_file()
     if [ -n "$RVM_SCRIPT" ]; then
         cat <<ENDINIT > $LAUNCHER_FILE
 #!/bin/bash
-DIRNAME="`dirname \$0`"
+DIRNAME="/usr/local/copperegg/ucm-metrics/dns"
 . $RVM_SCRIPT
 cd \$DIRNAME
 $AGENT_FILE \$*

--- a/dns/dns_installer.sh
+++ b/dns/dns_installer.sh
@@ -524,8 +524,20 @@ fi
 echo
 
 echo "Installing required gems "
-echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
-    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+echo "Installing gem bundler"
+gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+install_rc=$?
+if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem bundler did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install bundler -v 1.12.5 ' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+fi
 
 OLDIFS=$IFS
 IFS=$'\n'

--- a/dns/dns_installer.sh
+++ b/dns/dns_installer.sh
@@ -522,29 +522,46 @@ fi
 
 
 echo
-for THIS_GEM in `cat dns/Gemfile |grep '^[ ]*gem' |awk '{print $2}' | sed -r -e "s/[',]//g"`; do
-    echo "Installing gem $THIS_GEM..."
-    if [ -n "$PRE" -a -n "`echo $THIS_GEM | egrep copperegg`" ]; then
-        # install prerelease gems if "$PRE" is not null, but only for copperegg
-        gem install --no-ri --no-rdoc $THIS_GEM --pre --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
+
+echo "Installing required gems "
+echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
+    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+
+OLDIFS=$IFS
+IFS=$'\n'
+gems=`grep -w gem dns/Gemfile | awk '{$1="" ; print $0}'`
+
+for gem in $gems; do
+  gem=${gem//[\'\" ]/}
+  IFS=',' read -r -a array <<< "$gem"
+  echo "Installing gem ${array[0]}"
+  if [ -z "${array[1]}" ]
+    then
+    gem install --no-ri --no-rdoc ${array[0]} >> $PKG_INST_OUT
+  else
+    gem install --no-ri --no-rdoc ${array[0]} -v ${array[1]} >> $PKG_INST_OUT
+  fi
+
+  install_rc=$?
+  if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem ${array[0]} did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    if [ -z "${array[1]}" ]
+      then
+      echo "*** unable to run 'gem install ${array[0]}' manually."
     else
-        gem install --no-ri --no-rdoc $THIS_GEM --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
+      echo "*** unable to run 'gem install ${array[0]} -v \"${array[1]}\"' manually."
     fi
-    install_rc=$?
-    if [ $install_rc -ne 0 ]; then
-        echo
-        echo "********************************************************"
-        echo "********************************************************"
-        echo "*** "
-        echo "*** WARNING: gem $THIS_GEM did not install properly!"
-        echo "*** Please contact support-uptimecm@idera.com if you are"
-        echo "*** unable to run 'gem install $THIS_GEM' manually."
-        echo "*** "
-        echo "********************************************************"
-        echo "********************************************************"
-        echo
-    fi
+    echo "*** "
+    echo "********************************************************"
+    echo
+  fi
 done
+IFS=$OLDIFS
+
 
 # create config.yml
 

--- a/memcached/memcached.rb
+++ b/memcached/memcached.rb
@@ -6,6 +6,11 @@
 #
 # License:: MIT License
 
+base_path = '/usr/local/copperegg/ucm-metrics/memcached'
+ENV['BUNDLE_GEMFILE'] = "#{base_path}/Gemfile"
+
+##################################################
+
 require 'rubygems'
 require 'bundler/setup'
 require 'getoptlong'
@@ -310,7 +315,6 @@ opts = GetoptLong.new(
   ['--apihost',   '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-base_path = '/usr/local/copperegg/ucm-metrics/memcached'
 config_file = "#{base_path}/config.yml"
 
 @apihost = nil

--- a/memcached/memcached.rb
+++ b/memcached/memcached.rb
@@ -7,6 +7,7 @@
 # License:: MIT License
 
 require 'rubygems'
+require 'bundler/setup'
 require 'getoptlong'
 require 'copperegg'
 require 'json/pure'

--- a/memcached/memcached_installer.sh
+++ b/memcached/memcached_installer.sh
@@ -429,8 +429,20 @@ echo "Monitoring frequency set to one sample per $FREQ seconds."
 echo
 
 echo "Installing required gems "
-echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
-    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+echo "Installing gem bundler"
+gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+install_rc=$?
+if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem bundler did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install bundler -v 1.12.5 ' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+fi
 
 OLDIFS=$IFS
 IFS=$'\n'

--- a/memcached/memcached_installer.sh
+++ b/memcached/memcached_installer.sh
@@ -332,7 +332,7 @@ create_exe_file()
     if [ -n "$RVM_SCRIPT" ]; then
         cat <<ENDINIT > $LAUNCHER_FILE
 #!/bin/bash
-DIRNAME="`dirname \$0`"
+DIRNAME="/usr/local/copperegg/ucm-metrics/memcached"
 . $RVM_SCRIPT
 cd \$DIRNAME
 $AGENT_FILE \$*
@@ -428,29 +428,35 @@ echo "Monitoring frequency set to one sample per $FREQ seconds."
 
 echo
 
-for THIS_GEM in `cat memcached/Gemfile |grep '^[ ]*gem' |awk '{print $2}' | sed -r -e "s/[',]//g"`; do
-    echo "Installing gem $THIS_GEM..."
-    if [ -n "$PRE" -a -n "`echo $THIS_GEM | egrep copperegg`" ]; then
-        # install prerelease gems if "$PRE" is not null, but only for copperegg
-        gem install --no-ri --no-rdoc $THIS_GEM --pre --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
-    else
-        gem install --no-ri --no-rdoc $THIS_GEM --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
-    fi
-    install_rc=$?
-    if [ $install_rc -ne 0 ]; then
-        echo
-        echo "********************************************************"
-        echo "********************************************************"
-        echo "*** "
-        echo "*** WARNING: gem $THIS_GEM did not install properly!"
-        echo "*** Please contact support-uptimecm@idera.com if you are"
-        echo "*** unable to run 'gem install $THIS_GEM' manually."
-        echo "*** "
-        echo "********************************************************"
-        echo "********************************************************"
-        echo
-    fi
+echo "Installing required gems "
+echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
+    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+
+OLDIFS=$IFS
+IFS=$'\n'
+gems=`grep -w gem memcached/Gemfile | awk '{$1="" ; print $0}'`
+
+for gem in $gems; do
+  gem_name=`echo $gem | awk -F "," '{print $1}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+  gem_version=`echo $gem | awk -F "," '{print $2}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+
+  echo "Installing gem $gem_name [Using gem install $gem_name -v \"$gem_version\"]"
+
+  gem install $gem_name -v "$gem_version" >> $PKG_INST_OUT
+  install_rc=$?
+  if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem $gem did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install $gem_name -v \"$gem_version\"' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+  fi
 done
+IFS=$OLDIFS
 
 #
 # create config.yml

--- a/memcached/memcached_installer.sh
+++ b/memcached/memcached_installer.sh
@@ -437,20 +437,29 @@ IFS=$'\n'
 gems=`grep -w gem memcached/Gemfile | awk '{$1="" ; print $0}'`
 
 for gem in $gems; do
-  gem_name=`echo $gem | awk -F "," '{print $1}' | tr -d \' | tr -d \" | tr -d [:blank:]`
-  gem_version=`echo $gem | awk -F "," '{print $2}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+  gem=${gem//[\'\" ]/}
+  IFS=',' read -r -a array <<< "$gem"
+  echo "Installing gem ${array[0]}"
+  if [ -z "${array[1]}" ]
+    then
+    gem install --no-ri --no-rdoc ${array[0]} >> $PKG_INST_OUT
+  else
+    gem install --no-ri --no-rdoc ${array[0]} -v ${array[1]} >> $PKG_INST_OUT
+  fi
 
-  echo "Installing gem $gem_name [Using gem install $gem_name -v \"$gem_version\"]"
-
-  gem install $gem_name -v "$gem_version" >> $PKG_INST_OUT
   install_rc=$?
   if [ $install_rc -ne 0 ]; then
     echo
     echo "********************************************************"
     echo "*** "
-    echo "*** WARNING: gem $gem did not install properly!"
+    echo "*** WARNING: gem ${array[0]} did not install properly!"
     echo "*** Please contact support-uptimecm@idera.com if you are"
-    echo "*** unable to run 'gem install $gem_name -v \"$gem_version\"' manually."
+    if [ -z "${array[1]}" ]
+      then
+      echo "*** unable to run 'gem install ${array[0]}' manually."
+    else
+      echo "*** unable to run 'gem install ${array[0]} -v \"${array[1]}\"' manually."
+    fi
     echo "*** "
     echo "********************************************************"
     echo

--- a/mongodb/mongodb.rb
+++ b/mongodb/mongodb.rb
@@ -3,6 +3,11 @@
 # CopperEgg mongodb monitoring    mongodb.rb
 #
 
+base_path = '/usr/local/copperegg/ucm-metrics/mongodb'
+ENV['BUNDLE_GEMFILE'] = "#{base_path}/Gemfile"
+
+##################################################
+
 require 'rubygems'
 require 'bundler/setup'
 require 'getoptlong'
@@ -449,7 +454,6 @@ opts = GetoptLong.new(
     ['--apihost',   '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-base_path = '/usr/local/copperegg/ucm-metrics/mongodb'
 config_file = "#{base_path}/config.yml"
 @apihost = nil
 @debug = false

--- a/mongodb/mongodb_installer.sh
+++ b/mongodb/mongodb_installer.sh
@@ -539,28 +539,49 @@ fi
 echo "Monitoring frequency set to one sample per $FREQ seconds."
 
 echo "Installing required gems "
-echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
-    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+echo "Installing gem bundler"
+gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+install_rc=$?
+if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem bundler did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install bundler -v 1.12.5 ' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+fi
 
 OLDIFS=$IFS
 IFS=$'\n'
-gems=`grep -w gem mongodb/Gemfile | awk '{$1="" ; print $0}'`
+gems=`grep -w gem mongodb/Gemfile | awk '{$1="" ; print $0}'
 
 for gem in $gems; do
-  gem_name=`echo $gem | awk -F "," '{print $1}' | tr -d \' | tr -d \" | tr -d [:blank:]`
-  gem_version=`echo $gem | awk -F "," '{print $2}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+  gem=${gem//[\'\" ]/}
+  IFS=',' read -r -a array <<< "$gem"
+  echo "Installing gem ${array[0]}"
+  if [ -z "${array[1]}" ]
+    then
+    gem install --no-ri --no-rdoc ${array[0]} >> $PKG_INST_OUT
+  else
+    gem install --no-ri --no-rdoc ${array[0]} -v ${array[1]} >> $PKG_INST_OUT
+  fi
 
-  echo "Installing gem $gem_name [Using gem install $gem_name -v \"$gem_version\"]"
-
-  gem install $gem_name -v "$gem_version" >> $PKG_INST_OUT
   install_rc=$?
   if [ $install_rc -ne 0 ]; then
     echo
     echo "********************************************************"
     echo "*** "
-    echo "*** WARNING: gem $gem did not install properly!"
+    echo "*** WARNING: gem ${array[0]} did not install properly!"
     echo "*** Please contact support-uptimecm@idera.com if you are"
-    echo "*** unable to run 'gem install $gem_name -v \"$gem_version\"' manually."
+    if [ -z "${array[1]}" ]
+        then
+        echo "*** unable to run 'gem install ${array[0]}' manually."
+    else
+        echo "*** unable to run 'gem install ${array[0]} -v \"${array[1]}\"' manually."
+    fi 
     echo "*** "
     echo "********************************************************"
     echo

--- a/oracledb/oracledb.rb
+++ b/oracledb/oracledb.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'rubygems'
+require 'bundler/setup'
 require 'getoptlong'
 require 'copperegg'
 require 'json/pure'

--- a/oracledb/oracledb.rb
+++ b/oracledb/oracledb.rb
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
 
+base_path = '/usr/local/copperegg/ucm-metrics/oracledb'
+ENV['BUNDLE_GEMFILE'] = "#{base_path}/Gemfile"
+
+##################################################
+
 require 'rubygems'
 require 'bundler/setup'
 require 'getoptlong'
@@ -222,7 +227,6 @@ opts = GetoptLong.new(
     ['--apihost',   '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-base_path = '/usr/local/copperegg/ucm-metrics/oracledb'
 config_file = "#{base_path}/config.yml"
 
 @apihost = nil

--- a/oracledb/oracledb_installer.sh
+++ b/oracledb/oracledb_installer.sh
@@ -350,7 +350,9 @@ create_exe_file()
     if [ -n "$RVM_SCRIPT" ]; then
         cat <<ENDINIT > $LAUNCHER_FILE
 #!/bin/bash
+.DIRNAME="/usr/local/copperegg/ucm-metrics/oracledb"
 . $RVM_SCRIPT
+cd \$DIRNAME
 $AGENT_FILE \$*
 ENDINIT
         EXE_FILE=$LAUNCHER_FILE

--- a/oracledb/oracledb_installer.sh
+++ b/oracledb/oracledb_installer.sh
@@ -471,8 +471,20 @@ fi
 echo
 
 echo "Installing required gems "
-echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
-    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+echo "Installing gem bundler"
+gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+install_rc=$?
+if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem bundler did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install bundler -v 1.12.5 ' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+fi
 
 OLDIFS=$IFS
 IFS=$'\n'

--- a/postgresql/postgresql.rb
+++ b/postgresql/postgresql.rb
@@ -6,6 +6,11 @@
 # PostgreSQL queries are based on the PastgreSQL statistics gatherer,
 # written by Mahlon E. Smith <mahlon@martini.nu>,
 
+base_path = '/usr/local/copperegg/ucm-metrics/postgresql'
+ENV['BUNDLE_GEMFILE'] = "#{base_path}/Gemfile"
+
+##################################################
+
 require 'rubygems'
 require 'bundler/setup'
 require 'getoptlong'
@@ -86,7 +91,6 @@ opts = GetoptLong.new(
   ['--apihost',   '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-base_path = '/usr/local/copperegg/ucm-metrics/postgresql'
 config_file = "#{base_path}/config.yml"
 @apihost = nil
 @debug = false

--- a/postgresql/postgresql.rb
+++ b/postgresql/postgresql.rb
@@ -7,6 +7,7 @@
 # written by Mahlon E. Smith <mahlon@martini.nu>,
 
 require 'rubygems'
+require 'bundler/setup'
 require 'getoptlong'
 require 'copperegg'
 require 'json/pure'

--- a/postgresql/postgresql_installer.sh
+++ b/postgresql/postgresql_installer.sh
@@ -392,7 +392,7 @@ create_exe_file()
     if [ -n "$RVM_SCRIPT" ]; then
         cat <<ENDINIT > $LAUNCHER_FILE
 #!/bin/bash
-DIRNAME="/usr/local/copperegg/ucm-metrics/memcached"
+DIRNAME="/usr/local/copperegg/ucm-metrics/postgresql"
 . $RVM_SCRIPT
 cd \$DIRNAME
 $AGENT_FILE \$*

--- a/postgresql/postgresql_installer.sh
+++ b/postgresql/postgresql_installer.sh
@@ -528,8 +528,20 @@ fi
 echo
 
 echo "Installing required gems "
-echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
-    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+echo "Installing gem bundler"
+gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+install_rc=$?
+if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem bundler did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install bundler -v 1.12.5 ' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+fi
 
 OLDIFS=$IFS
 IFS=$'\n'

--- a/postgresql/postgresql_installer.sh
+++ b/postgresql/postgresql_installer.sh
@@ -392,7 +392,9 @@ create_exe_file()
     if [ -n "$RVM_SCRIPT" ]; then
         cat <<ENDINIT > $LAUNCHER_FILE
 #!/bin/bash
+DIRNAME="/usr/local/copperegg/ucm-metrics/memcached"
 . $RVM_SCRIPT
+cd \$DIRNAME
 $AGENT_FILE \$*
 ENDINIT
         EXE_FILE=$LAUNCHER_FILE
@@ -524,29 +526,36 @@ fi
 
 
 echo
-for THIS_GEM in `cat postgresql/Gemfile |grep '^[ ]*gem' |awk '{print $2}' | sed -r -e "s/[',]//g"`; do
-    echo "Installing gem $THIS_GEM..."
-    if [ -n "$PRE" -a -n "`echo $THIS_GEM | egrep copperegg`" ]; then
-        # install prerelease gems if "$PRE" is not null, but only for copperegg
-        gem install --no-ri --no-rdoc $THIS_GEM --pre --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
-    else
-        gem install --no-ri --no-rdoc $THIS_GEM --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
-    fi
-    install_rc=$?
-    if [ $install_rc -ne 0 ]; then
-        echo
-        echo "********************************************************"
-        echo "********************************************************"
-        echo "*** "
-        echo "*** WARNING: gem $THIS_GEM did not install properly!"
-        echo "*** Please contact support-uptimecm@idera.com if you are"
-        echo "*** unable to run 'gem install $THIS_GEM' manually."
-        echo "*** "
-        echo "********************************************************"
-        echo "********************************************************"
-        echo
-    fi
+
+echo "Installing required gems "
+echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
+    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+
+OLDIFS=$IFS
+IFS=$'\n'
+gems=`grep -w gem postgresql/Gemfile | awk '{$1="" ; print $0}'`
+
+for gem in $gems; do
+  gem_name=`echo $gem | awk -F "," '{print $1}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+  gem_version=`echo $gem | awk -F "," '{print $2}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+
+  echo "Installing gem $gem_name [Using gem install $gem_name -v \"$gem_version\"]"
+
+  gem install $gem_name -v "$gem_version" >> $PKG_INST_OUT
+  install_rc=$?
+  if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem $gem did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install $gem_name -v \"$gem_version\"' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+  fi
 done
+IFS=$OLDIFS
 
 
 #

--- a/postgresql/postgresql_installer.sh
+++ b/postgresql/postgresql_installer.sh
@@ -536,20 +536,29 @@ IFS=$'\n'
 gems=`grep -w gem postgresql/Gemfile | awk '{$1="" ; print $0}'`
 
 for gem in $gems; do
-  gem_name=`echo $gem | awk -F "," '{print $1}' | tr -d \' | tr -d \" | tr -d [:blank:]`
-  gem_version=`echo $gem | awk -F "," '{print $2}' | tr -d \' | tr -d \" | tr -d [:blank:]`
+  gem=${gem//[\'\" ]/}
+  IFS=',' read -r -a array <<< "$gem"
+  echo "Installing gem ${array[0]}"
+  if [ -z "${array[1]}" ]
+    then
+    gem install --no-ri --no-rdoc ${array[0]} >> $PKG_INST_OUT
+  else
+    gem install --no-ri --no-rdoc ${array[0]} -v ${array[1]} >> $PKG_INST_OUT
+  fi
 
-  echo "Installing gem $gem_name [Using gem install $gem_name -v \"$gem_version\"]"
-
-  gem install $gem_name -v "$gem_version" >> $PKG_INST_OUT
   install_rc=$?
   if [ $install_rc -ne 0 ]; then
     echo
     echo "********************************************************"
     echo "*** "
-    echo "*** WARNING: gem $gem did not install properly!"
+    echo "*** WARNING: gem ${array[0]} did not install properly!"
     echo "*** Please contact support-uptimecm@idera.com if you are"
-    echo "*** unable to run 'gem install $gem_name -v \"$gem_version\"' manually."
+    if [ -z "${array[1]}" ]
+      then
+      echo "*** unable to run 'gem install ${array[0]}' manually."
+    else
+      echo "*** unable to run 'gem install ${array[0]} -v \"${array[1]}\"' manually."
+    fi
     echo "*** "
     echo "********************************************************"
     echo

--- a/remote_server/remote_server.rb
+++ b/remote_server/remote_server.rb
@@ -4,6 +4,7 @@
 #
 
 require 'rubygems'
+require 'bundler/setup'
 require 'getoptlong'
 require 'copperegg'
 require 'json/pure'

--- a/remote_server/remote_server.rb
+++ b/remote_server/remote_server.rb
@@ -3,6 +3,11 @@
 # Copyright 2016 IDERA.  All rights reserved.
 #
 
+@base_path = '/usr/local/copperegg/ucm-metrics/remote_server/'
+ENV['BUNDLE_GEMFILE'] = "#{@base_path}/Gemfile"
+
+##################################################
+
 require 'rubygems'
 require 'bundler/setup'
 require 'getoptlong'
@@ -43,7 +48,6 @@ opts = GetoptLong.new(
   ['--apihost',   '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
-@base_path = '/usr/local/copperegg/ucm-metrics/remote_server/'
 config_file = "#{@base_path}config.yml"
 @apihost = nil
 @debug = false

--- a/remote_server/remote_server_installer.sh
+++ b/remote_server/remote_server_installer.sh
@@ -403,7 +403,7 @@ create_exe_file()
     if [ -n "$RVM_SCRIPT" ]; then
         cat <<ENDINIT > $LAUNCHER_FILE
 #!/bin/bash
-DIRNAME="`dirname \$0`"
+DIRNAME="/usr/local/copperegg/ucm-metrics/remote_server"
 . $RVM_SCRIPT
 cd \$DIRNAME
 $AGENT_FILE \$*

--- a/remote_server/remote_server_installer.sh
+++ b/remote_server/remote_server_installer.sh
@@ -497,8 +497,20 @@ echo "Monitoring frequency set to one sample per $FREQ seconds."
 echo
 
 echo "Installing required gems "
-echo "Installing gem bundler [Using gem install bundler -v \"1.12.5\"]"
-    gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+echo "Installing gem bundler"
+gem install bundler -v "1.12.5" >> $PKG_INST_OUT
+install_rc=$?
+if [ $install_rc -ne 0 ]; then
+    echo
+    echo "********************************************************"
+    echo "*** "
+    echo "*** WARNING: gem bundler did not install properly!"
+    echo "*** Please contact support-uptimecm@idera.com if you are"
+    echo "*** unable to run 'gem install bundler -v 1.12.5 ' manually."
+    echo "*** "
+    echo "********************************************************"
+    echo
+fi
 
 OLDIFS=$IFS
 IFS=$'\n'


### PR DESCRIPTION
```
for THIS_GEM in `cat postgresql/Gemfile |grep '^[ ]*gem' |awk '{print $2}' | sed -r -e "s/[',]//g"`; do
    echo "Installing gem $THIS_GEM..."
    if [ -n "$PRE" -a -n "`echo $THIS_GEM | egrep copperegg`" ]; then
        # install prerelease gems if "$PRE" is not null, but only for copperegg
        gem install --no-ri --no-rdoc $THIS_GEM --pre --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
    else
        gem install --no-ri --no-rdoc $THIS_GEM --source 'http://rubygems.org' >> $PKG_INST_OUT 2>&1
    fi
end
```

We grep dependency gems from Gemfile, but only do a gem install which indicates installing latest gem. This can cause a version conflict.
