### PR TITLE
Close psql connection after fetching metrics data

### DIFF
--- a/postgresql/postgresql.rb
+++ b/postgresql/postgresql.rb
@@ -289,7 +289,8 @@ def monitor_postgresql(pg_servers, group_name)
       pg_dbs.each do |db|
         return if @interrupted
         begin
-          pgcxn = connect_to_postgresql(mhost['hostname'], mhost['port'].to_i, db['username'], db['password'], db['name'], mhost['sslmode'])
+          pgcxn = connect_to_postgresql(mhost['hostname'], mhost['port'].to_i, db['username'], db['password'],
+                                        db['name'], mhost['sslmode'])
           if pgcxn == nil
             log '[skipping]'
             next


### PR DESCRIPTION
Closed psql connection manually after fetching metrics data.